### PR TITLE
Add JsonEncoder and JsonDecoder implmentations to their Bson counterparts

### DIFF
--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
     implementation(platform("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.5.0"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json")
 
     api(project(path = ":bson", configuration = "default"))
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -218,9 +218,12 @@ internal class DefaultBsonEncoder(
                 else -> {
                     val decimal = BigDecimal(content)
                     when  {
-                        decimal.stripTrailingZeros().scale() > 0 &&
-                                DOUBLE_MIN_VALUE <= decimal && decimal <= DOUBLE_MAX_VALUE ->
-                            encodeDouble(element.double)
+                        decimal.stripTrailingZeros().scale() > 0 ->
+                            if (DOUBLE_MIN_VALUE <= decimal && decimal <= DOUBLE_MAX_VALUE) {
+                                encodeDouble(element.double)
+                            } else {
+                                writer.writeDecimal128(Decimal128(decimal))
+                            }
                         INT_MIN_VALUE <= decimal && decimal <= INT_MAX_VALUE ->
                             encodeInt(element.int)
                         LONG_MIN_VALUE <= decimal && decimal <= LONG_MAX_VALUE ->

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import org.bson.BsonArray
 import org.bson.BsonBinary
 import org.bson.BsonBoolean
@@ -49,6 +50,11 @@ import org.bson.codecs.pojo.annotations.BsonIgnore
 import org.bson.codecs.pojo.annotations.BsonProperty
 import org.bson.codecs.pojo.annotations.BsonRepresentation
 import org.bson.types.ObjectId
+
+@Serializable
+data class DataClassWithJsonElement(
+    val value: JsonElement
+)
 
 @Serializable
 data class DataClassWithSimpleValues(


### PR DESCRIPTION
Kotlinx requires the encoder to implement `JsonEncoder` and `JsonDecoder` in order to encode generic `JsonElement` types.

The lack of this support for this came up many times when using [KBson](https://github.com/jershell/kbson) and [KMongo](https://github.com/Litote/kmongo) previously and I'm hoping we can quickly mitigate this now that MongoDB has official support.

I've added each implementation to support most types on decoding and determine the best possible type on encoding to insert. It is somewhat assumed that if someone is encoding a `JsonElement`, then they will probably be decoding one as well and, therefore, type information is primarily for storage optimization.

Unfortunately, Kotlinx writes all numbers as 64 bit integers first and never attempts to check for 32 bits or allow overriding the `JsonElementSerializer` behavior; this means that all integers will probably be written as `int64`. Regardless, this should be a valuable add.